### PR TITLE
Display ConfigAuditReport in the workload details pane

### DIFF
--- a/renderer.tsx
+++ b/renderer.tsx
@@ -14,6 +14,7 @@ import {CISKubeBenchReportsList} from "./src/components/ciskubebench-reports-lis
 import {CISKubeBenchReport} from "./src/ciskubebench-report";
 import {CISKubeBenchReportDetails, CISKubeBenchReportDetailsProps} from "./src/components/ciskubebench-report-details";
 import {WorkloadVulnerabilities} from "./src/components/workload-vulnerabilities";
+import {WorkloadConfigAudit} from "./src/components/workload-configaudit";
 
 export function CertificateIcon(props: Component.IconProps) {
     return <Component.Icon {...props} material="security"/>
@@ -96,51 +97,65 @@ export default class StarboardExtension extends LensRendererExtension {
 
     kubeObjectDetailItems = [
         {
-            kind: 'Pod',
-            apiVersions: ['v1'],
-            priority: 10,
+            kind: "Pod",
+            apiVersions: ["v1"],
+            priority: 9,
             components: {
                 Details: (props: Component.KubeObjectDetailsProps) =>
-                    <WorkloadVulnerabilities {...props} />
+                    <React.Fragment>
+                        <WorkloadConfigAudit {...props} />
+                        <WorkloadVulnerabilities {...props}/>
+                    </React.Fragment>
             }
         },
         {
             kind: "Deployment",
             apiVersions: ["apps/v1"],
-            priority: 10,
+            priority: 9,
             components: {
                 Details: (props: Component.KubeObjectDetailsProps) =>
-                    <WorkloadVulnerabilities {...props} />
+                    <React.Fragment>
+                        <WorkloadConfigAudit {...props} />
+                        <WorkloadVulnerabilities {...props}/>
+                    </React.Fragment>
             }
         },
         {
-            kind: 'DaemonSet',
-            apiVersions: ['apps/v1'],
-            priority: 10,
+            kind: "DaemonSet",
+            apiVersions: ["apps/v1"],
+            priority: 9,
             components: {
                 Details: (props: Component.KubeObjectDetailsProps) =>
-                    <WorkloadVulnerabilities {...props} />
+                    <React.Fragment>
+                        <WorkloadConfigAudit {...props} />
+                        <WorkloadVulnerabilities {...props}/>
+                    </React.Fragment>
             }
         },
         {
-            kind: 'StatefulSet',
-            apiVersions: ['apps/v1'],
-            priority: 10,
+            kind: "StatefulSet",
+            apiVersions: ["apps/v1"],
+            priority: 9,
             components: {
                 Details: (props: Component.KubeObjectDetailsProps) =>
-                    <WorkloadVulnerabilities {...props} />
+                    <React.Fragment>
+                        <WorkloadConfigAudit {...props} />
+                        <WorkloadVulnerabilities {...props}/>
+                    </React.Fragment>
             }
         },
         {
             kind: "ReplicaSet",
             apiVersions: ["apps/v1"],
-            priority: 10,
+            priority: 9,
             components: {
                 Details: (props: Component.KubeObjectDetailsProps) =>
-                    <WorkloadVulnerabilities {...props} />
+                    <React.Fragment>
+                        <WorkloadConfigAudit {...props} />
+                        <WorkloadVulnerabilities {...props}/>
+                    </React.Fragment>
             }
         },
-
         {
             kind: VulnerabilityReport.kind,
             apiVersions: ["aquasecurity.github.io/v1alpha1"],
@@ -153,7 +168,8 @@ export default class StarboardExtension extends LensRendererExtension {
             kind: ConfigAuditReport.kind,
             apiVersions: ["aquasecurity.github.io/v1alpha1"],
             components: {
-                Details: (props: ConfigAuditReportDetailsProps) => <ConfigAuditReportDetails {...props} />
+                Details: (props: ConfigAuditReportDetailsProps) => <ConfigAuditReportDetails
+                    showObjectMeta {...props} />
             }
         },
         {

--- a/src/components/checks-list.tsx
+++ b/src/components/checks-list.tsx
@@ -1,6 +1,7 @@
 import {Check} from "../configaudit-report";
 import React from "react";
 import {Component} from "@k8slens/extensions";
+import {VulnerabilitiesList} from "./vulnerabilities-list";
 
 interface Props {
     title: string;
@@ -13,10 +14,10 @@ export class ChecksList extends React.Component<Props> {
         const {checks} = this.props;
         return (
             <Component.TableRow key={checks[index].checkID} nowrap>
-                <Component.TableCell className="xsuccess">{"" + checks[index].success}</Component.TableCell>
+                <Component.TableCell className="checkSuccess">{"" + checks[index].success}</Component.TableCell>
                 <Component.TableCell className="checkID">{checks[index].checkID}</Component.TableCell>
-                <Component.TableCell className="severity">{checks[index].severity}</Component.TableCell>
-                <Component.TableCell className="category">{checks[index].category}</Component.TableCell>
+                <Component.TableCell className="checkSeverity">{checks[index].severity}</Component.TableCell>
+                <Component.TableCell className="checkCategory">{checks[index].category}</Component.TableCell>
             </Component.TableRow>
         )
     }
@@ -28,19 +29,29 @@ export class ChecksList extends React.Component<Props> {
         }
 
         return (
-            <div>
-                <Component.DrawerTitle title={title}/>
-                <Component.Table className="box grow">
-                    <Component.TableHead>
-                        <Component.TableCell className="xsuccess">Success</Component.TableCell>
-                        <Component.TableCell className="checkID">ID</Component.TableCell>
-                        <Component.TableCell className="severity">Severity</Component.TableCell>
-                        <Component.TableCell className="category">Category</Component.TableCell>
-                    </Component.TableHead>
-                    {
-                        checks.map((check, index) => this.getTableRow(index))
-                    }
-                </Component.Table>
+            <div className="PodDetailsContainer">
+                {1 === 1 &&
+                <div className="pod-container-title">
+                    <Component.StatusBrick
+                        className="error"/>{title}
+                </div>}
+
+                <Component.DrawerItem name="Checks">
+                    <Component.DrawerParamToggler label={checks.length}>
+                        <Component.Table>
+                            <Component.TableHead>
+                                <Component.TableCell className="checkSuccess">Success</Component.TableCell>
+                                <Component.TableCell className="checkID">ID</Component.TableCell>
+                                <Component.TableCell className="checkSeverity">Severity</Component.TableCell>
+                                <Component.TableCell className="checkCategory">Category</Component.TableCell>
+                            </Component.TableHead>
+                            {
+                                checks.map((check, index) => this.getTableRow(index))
+                            }
+                        </Component.Table>
+                    </Component.DrawerParamToggler>
+                </Component.DrawerItem>
+
             </div>
         )
     }

--- a/src/components/configaudit-checks-list.tsx
+++ b/src/components/configaudit-checks-list.tsx
@@ -16,9 +16,9 @@ export class ConfigAuditChecksList extends React.Component<Props> {
 
         return (
             <div>
-                <ChecksList title="Pod Template Checks" checks={podChecks}/>
+                <ChecksList title="" checks={podChecks}/>
                 {
-                    Object.keys(containerChecks).map((key, index) => <ChecksList title={"Container Checks " + key}
+                    Object.keys(containerChecks).map((key, index) => <ChecksList title={key}
                                                                                  checks={containerChecks[key]}/>)
                 }
             </div>

--- a/src/components/configaudit-report-details.tsx
+++ b/src/components/configaudit-report-details.tsx
@@ -4,6 +4,14 @@ import {ConfigAuditReport} from "../configaudit-report";
 import {ConfigAuditChecksList} from "./configaudit-checks-list";
 
 export interface ConfigAuditReportDetailsProps extends Component.KubeObjectDetailsProps<ConfigAuditReport> {
+
+    /*
+     * Determines whether to display ObjectMeta section or not.
+     * We want to display it in the generic ConfigAuditReport view.
+     * However, we want to hide it when we show ConfigAuditReport
+     * in the WorkloadConfigAudit details pane.
+     */
+    showObjectMeta?: boolean
 }
 
 export class ConfigAuditReportDetails extends React.Component<ConfigAuditReportDetailsProps> {
@@ -13,7 +21,9 @@ export class ConfigAuditReportDetails extends React.Component<ConfigAuditReportD
         if (!report) return null;
         return (
             <div className="ConfigAuditReport">
-                <Component.KubeObjectMeta object={report} hideFields={["uid", "resourceVersion", "selfLink"]}/>
+                {this.props.showObjectMeta &&
+                <Component.KubeObjectMeta object={report} hideFields={["uid", "resourceVersion", "selfLink"]}/>}
+
                 <Component.DrawerItem name="Danger">
                     {report.report.summary.dangerCount}
                 </Component.DrawerItem>

--- a/src/components/vulnerability-report-details.tsx
+++ b/src/components/vulnerability-report-details.tsx
@@ -4,6 +4,7 @@ import {VulnerabilityReport} from "../vulnerability-report";
 import {VulnerabilitiesList} from "./vulnerabilities-list";
 
 export interface VulnerabilityReportDetailsProps extends Component.KubeObjectDetailsProps<VulnerabilityReport> {
+
     /*
      * Determines whether to display container name with a little rectangle.
      * If the rectangle is green there are no action. If it's red it means
@@ -15,8 +16,8 @@ export interface VulnerabilityReportDetailsProps extends Component.KubeObjectDet
     /*
      * Determines whether to display ObjectMeta section or not.
      * We want to display it in the generic VulnerabilityReport view.
-     * However, when we list VulnerabilityReports in the WorkloadVulnerabilities
-     * details pane we want to hide it.
+     * However, we want to hide it when we list VulnerabilityReports
+     * in the WorkloadVulnerabilities details pane.
      */
     showObjectMeta?: boolean
 }

--- a/src/components/workload-configaudit.tsx
+++ b/src/components/workload-configaudit.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import {Component} from "@k8slens/extensions";
+import {configAuditReportsStore} from "../configaudit-reports-store";
+import {ConfigAuditReportDetails} from "./configaudit-report-details";
+
+/*
+ * This component is trying to lookup the ConfigAuditReport associated with the
+ * specified Kubernetes workload and then render it.
+ */
+export class WorkloadConfigAudit extends React.Component<Component.KubeObjectDetailsProps> {
+
+    async componentDidMount() {
+        await configAuditReportsStore.loadAll()
+    }
+
+    render() {
+        const {object: workload} = this.props;
+
+        const selector = [
+            "starboard.resource.kind=" + workload.kind,
+            "starboard.resource.name=" + workload.getName(),
+            "starboard.resource.namespace=" + workload.getNs()
+        ];
+
+        const configAuditReports = configAuditReportsStore.getByLabel(selector)
+
+        return (
+            <div>
+                <Component.DrawerTitle title="ConfigAuditReport"/>
+                {configAuditReports.length == 0 && <div>N/A</div>}
+                {
+                    configAuditReports.map((report) => {
+                        return (
+                            <ConfigAuditReportDetails object={report}/>
+                        );
+                    })
+                }
+            </div>
+        )
+    }
+
+}

--- a/src/components/workload-vulnerabilities.tsx
+++ b/src/components/workload-vulnerabilities.tsx
@@ -25,6 +25,7 @@ export class WorkloadVulnerabilities extends React.Component<Component.KubeObjec
         return (
             <div>
                 <Component.DrawerTitle title="VulnerabilityReports"/>
+                {vulnerabilityReports.length == 0 && <div>N/A</div>}
                 {
                     vulnerabilityReports.map((report) => {
                         return (


### PR DESCRIPTION
The goal of this PR is to display ConfigAuditReport for the selected K8S workload. By default the report shows the summary of checks per pod and each container. Each group of checks has the status icon. If it's red a user can drill down and see which exact checks were performed and which one is actually failing.

![workload_configaudit_overview](https://user-images.githubusercontent.com/1322923/100107433-ebf3cf80-2e69-11eb-96f8-2f320154db6a.png)

![workload_config_audit_details](https://user-images.githubusercontent.com/1322923/100107650-2b222080-2e6a-11eb-9562-0add505c35f0.png)


Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>