### PR TITLE
feat: Add AVD and other associated info links

### DIFF
--- a/src/components/vulnerabilities-list.tsx
+++ b/src/components/vulnerabilities-list.tsx
@@ -10,25 +10,26 @@ export class VulnerabilitiesList extends React.Component<Props> {
 
     getTableRow(index: number) {
         const {vulnerabilities} = this.props;
-
-        let avdURL: JSX.Element;
+        let avdURL: string;
         let vulnID = vulnerabilities[index].vulnerabilityID;
 
         if (vulnID.startsWith('CVE-')) {
-            avdURL =  <a target="_blank" href={`https://avd.aquasec.com/nvd/${vulnID}`.toLowerCase()}>{vulnID}</a>;
+            avdURL =  `https://avd.aquasec.com/nvd/${vulnID}`.toLowerCase()
         } else if (vulnID.startsWith('RUSTSEC-')) {
-            avdURL =  <a target="_blank" href={`https://rustsec.org/advisories/${vulnID}`}>{vulnID}</a>;
+            avdURL =  `https://rustsec.org/advisories/${vulnID}`
         } else if (vulnID.startsWith('GHSA-')) {
-            avdURL =  <a target="_blank" href={`https://github.com/advisories/${vulnID}`}>{vulnID}</a>;
+            avdURL =  `https://github.com/advisories/${vulnID}`
         } else if (vulnID.startsWith('TEMP-')) {
-            avdURL =  <a target="_blank" href={`https://security-tracker.debian.org/tracker/${vulnID}`}>{vulnID}</a>;
+            avdURL =  `https://security-tracker.debian.org/tracker/${vulnID}`
         } else {
-            avdURL =  <a target="_blank" href={`https://google.com/search?q=${vulnID}`}>{vulnID}</a>;
+            avdURL =  `https://google.com/search?q=${vulnID}`
         }
 
         return (
             <Component.TableRow key={vulnID} nowrap>
-                <Component.TableCell className="vulnerabilityID">{avdURL}</Component.TableCell>
+                <Component.TableCell className="vulnerabilityID">
+                    <a target="_blank" href={avdURL}>{vulnID}</a>
+                    </Component.TableCell>
                 <Component.TableCell className="severity">{vulnerabilities[index].severity}</Component.TableCell>
                 <Component.TableCell className="resource">{vulnerabilities[index].resource}</Component.TableCell>
                 <Component.TableCell

--- a/src/components/vulnerabilities-list.tsx
+++ b/src/components/vulnerabilities-list.tsx
@@ -10,10 +10,25 @@ export class VulnerabilitiesList extends React.Component<Props> {
 
     getTableRow(index: number) {
         const {vulnerabilities} = this.props;
+
+        let avdURL: JSX.Element;
+        let vulnID = vulnerabilities[index].vulnerabilityID;
+
+        if (vulnID.startsWith('CVE-')) {
+            avdURL =  <a target="_blank" href={`https://avd.aquasec.com/nvd/${vulnID}`.toLowerCase()}>{vulnID}</a>;
+        } else if (vulnID.startsWith('RUSTSEC-')) {
+            avdURL =  <a target="_blank" href={`https://rustsec.org/advisories/${vulnID}`}>{vulnID}</a>;
+        } else if (vulnID.startsWith('GHSA-')) {
+            avdURL =  <a target="_blank" href={`https://github.com/advisories/${vulnID}`}>{vulnID}</a>;
+        } else if (vulnID.startsWith('TEMP-')) {
+            avdURL =  <a target="_blank" href={`https://security-tracker.debian.org/tracker/${vulnID}`}>{vulnID}</a>;
+        } else {
+            avdURL =  <a target="_blank" href={`https://google.com/search?q=${vulnID}`}>{vulnID}</a>;
+        }
+
         return (
-            <Component.TableRow key={vulnerabilities[index].vulnerabilityID} nowrap>
-                <Component.TableCell
-                    className="vulnerabilityID">{vulnerabilities[index].vulnerabilityID}</Component.TableCell>
+            <Component.TableRow key={vulnID} nowrap>
+                <Component.TableCell className="vulnerabilityID">{avdURL}</Component.TableCell>
                 <Component.TableCell className="severity">{vulnerabilities[index].severity}</Component.TableCell>
                 <Component.TableCell className="resource">{vulnerabilities[index].resource}</Component.TableCell>
                 <Component.TableCell


### PR DESCRIPTION
Addresses: https://github.com/aquasecurity/starboard-lens-extension/issues/23

<img width="1225" alt="image" src="https://user-images.githubusercontent.com/1254783/100172104-747b6b80-2e7c-11eb-8faa-7f3c205b6150.png">

Clicking on the vulnerability ID opens the link in a browser window.

Signed-off-by: Simarpreet Singh <simar@linux.com>