### PR TITLE
feat: Display CIS Kubernetes Benchmark results in the Node details pane

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This guide shows how to install the extension either from from pre-built binary 
 
 ### From the Binary Releases
 
-Every [release][release] of Lens extension for Starboard provides the tarball-file that can be manually
+Every [release][releases] of Lens extension for Starboard provides the tarball-file that can be manually
 downloaded and installed. Alternatively, you can copy the download URL of the release artifact to paste it in the
 **Manage Lens Extensions** page.
 

--- a/renderer.tsx
+++ b/renderer.tsx
@@ -15,6 +15,7 @@ import {CISKubeBenchReport} from "./src/ciskubebench-report";
 import {CISKubeBenchReportDetails, CISKubeBenchReportDetailsProps} from "./src/components/ciskubebench-report-details";
 import {WorkloadVulnerabilities} from "./src/components/workload-vulnerabilities";
 import {WorkloadConfigAudit} from "./src/components/workload-configaudit";
+import {NodeBenchmarks} from "./src/components/node-benchmarks";
 
 export function CertificateIcon(props: Component.IconProps) {
     return <Component.Icon {...props} material="security"/>
@@ -97,6 +98,17 @@ export default class StarboardExtension extends LensRendererExtension {
 
     kubeObjectDetailItems = [
         {
+            kind: "Node",
+            apiVersions: ["v1"],
+            priority: 9,
+            components: {
+                Details: (props: Component.KubeObjectDetailsProps) =>
+                    <React.Fragment>
+                        <NodeBenchmarks {...props} />
+                    </React.Fragment>
+            }
+        },
+        {
             kind: "Pod",
             apiVersions: ["v1"],
             priority: 9,
@@ -176,7 +188,8 @@ export default class StarboardExtension extends LensRendererExtension {
             kind: CISKubeBenchReport.kind,
             apiVersions: ["aquasecurity.github.io/v1alpha1"],
             components: {
-                Details: (props: CISKubeBenchReportDetailsProps) => <CISKubeBenchReportDetails {...props} />
+                Details: (props: CISKubeBenchReportDetailsProps) => <CISKubeBenchReportDetails
+                    showObjectMeta {...props} />
             }
         }
     ]

--- a/src/components/ciskubebench-report-details.tsx
+++ b/src/components/ciskubebench-report-details.tsx
@@ -4,6 +4,7 @@ import {CISKubeBenchReport} from "../ciskubebench-report";
 import {CISSectionsList} from "./cissections-list";
 
 export interface CISKubeBenchReportDetailsProps extends Component.KubeObjectDetailsProps<CISKubeBenchReport> {
+    showObjectMeta?: boolean
 }
 
 export class CISKubeBenchReportDetails extends React.Component<CISKubeBenchReportDetailsProps> {
@@ -13,18 +14,19 @@ export class CISKubeBenchReportDetails extends React.Component<CISKubeBenchRepor
         if (!report) return null;
         return (
             <div className="CISKubeBenchReport">
-                <Component.KubeObjectMeta object={report} hideFields={["uid", "resourceVersion", "selfLink"]}/>
+                {this.props.showObjectMeta &&
+                <Component.KubeObjectMeta object={report} hideFields={["uid", "resourceVersion", "selfLink"]}/>}
                 <Component.DrawerItem name="Fail">
                     {report.report.summary.failCount}
+                </Component.DrawerItem>
+                <Component.DrawerItem name="Warn">
+                    {report.report.summary.warnCount}
                 </Component.DrawerItem>
                 <Component.DrawerItem name="Info">
                     {report.report.summary.infoCount}
                 </Component.DrawerItem>
                 <Component.DrawerItem name="Pass">
                     {report.report.summary.passCount}
-                </Component.DrawerItem>
-                <Component.DrawerItem name="Warn">
-                    {report.report.summary.warnCount}
                 </Component.DrawerItem>
 
                 <CISSectionsList sections={report.report.sections}/>

--- a/src/components/ciskubebench-reports-list.tsx
+++ b/src/components/ciskubebench-reports-list.tsx
@@ -33,17 +33,18 @@ export class CISKubeBenchReportsList extends React.Component<{ extension: LensRe
                     {title: "Name", className: "name", sortBy: sortBy.name},
                     {title: "Scanner", className: "scanner"},
                     {title: "Fail", className: "fail", sortBy: sortBy.fail},
+                    {title: "Warn", className: "pass", sortBy: sortBy.warn},
                     {title: "Info", className: "xinfo", sortBy: sortBy.info},
                     {title: "Pass", className: "pass", sortBy: sortBy.pass},
-                    {title: "Warn", className: "pass", sortBy: sortBy.warn},
+
                 ]}
                 renderTableContents={(report: CISKubeBenchReport) => [
                     report.getName(),
                     report.report.scanner.name + " " + report.report.scanner.version,
                     report.report.summary.failCount,
+                    report.report.summary.warnCount,
                     report.report.summary.infoCount,
                     report.report.summary.passCount,
-                    report.report.summary.warnCount,
                 ]}
             />
         )

--- a/src/components/node-benchmarks.tsx
+++ b/src/components/node-benchmarks.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import {Component} from "@k8slens/extensions";
+import {cisKubeBenchReportsStore} from "../ciskubebench-reports-store";
+import {CISKubeBenchReportDetails} from "./ciskubebench-report-details";
+
+export class NodeBenchmarks extends React.Component<Component.KubeObjectDetailsProps> {
+
+    render() {
+        const {object: node} = this.props;
+
+        const report = cisKubeBenchReportsStore.getByName(node.getName())
+
+        return (
+            <div>
+                <Component.DrawerTitle title="CIS Kubernetes Benchmarks"/>
+                <CISKubeBenchReportDetails object={report}/>
+            </div>
+        )
+    }
+}


### PR DESCRIPTION
![lens_kube_bench](https://user-images.githubusercontent.com/1322923/108390239-c1b77100-7210-11eb-8cff-a8ba5b177340.png)

Resolves: #37

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>