### PR TITLE
Fix rendering of ConfigAuditReport with exempted containers

### DIFF
--- a/src/configauditreports/checks-list.tsx
+++ b/src/configauditreports/checks-list.tsx
@@ -26,7 +26,7 @@ export class ChecksList extends React.Component<Props> {
 
     render() {
         const {checks, title} = this.props
-        if (!checks.length) {
+        if (!checks || !checks.length) {
             return null;
         }
 


### PR DESCRIPTION
Fixes #70. I tested this on my local machine and the ConfigAuditReport in question now renders correctly with this change.

FYI I notice probably the same issue in https://github.com/aquasecurity/starboard-lens-extension/blob/v0.4.0/src/vulnerabilityreports/list.tsx#L73-L77