### PR TITLE
feat: Show color badges for severity on reports lists

### DIFF
--- a/src/ciskubebenchreports/page.scss
+++ b/src/ciskubebenchreports/page.scss
@@ -1,0 +1,24 @@
+.CISKubeBenchReportsList {
+
+  .Badge {
+    &.theme-fail {
+      color: white;
+      background-color: #cc1814;
+    }
+
+    &.theme-warn {
+      color: white;
+      background-color: #ffa500;
+    }
+
+    &.theme-info {
+      color: white;
+      background-color: #515456;
+    }
+
+    &.theme-pass {
+      color: white;
+      background-color: #00b09b;
+    }
+  }
+}

--- a/src/ciskubebenchreports/page.tsx
+++ b/src/ciskubebenchreports/page.tsx
@@ -65,7 +65,7 @@ function renderResult(result: string, count: number) {
     )
   } else {
     return (
-        <Badge flat small key="result" label={count}/>
+        <Badge small key="result" label={count}/>
     )
   } 
 }

--- a/src/ciskubebenchreports/page.tsx
+++ b/src/ciskubebenchreports/page.tsx
@@ -1,7 +1,15 @@
+import "./page.scss"
 import {Renderer} from "@k8slens/extensions";
 import React from "react";
 import {store} from "./store";
 import {CISKubeBenchReport} from "./types";
+
+const {
+    Component: {
+        KubeObjectListLayout,
+        Badge
+    }
+} = Renderer;
 
 enum sortBy {
     name = "name",
@@ -15,7 +23,7 @@ export class CISKubeBenchReportsPage extends React.Component<{ extension: Render
 
     render() {
         return (
-            <Renderer.Component.KubeObjectListLayout
+            <KubeObjectListLayout
                 tableId="kubeBenchReportsTable"
                 className="CISKubeBenchReportsList" store={store}
                 sortingCallbacks={{
@@ -39,13 +47,25 @@ export class CISKubeBenchReportsPage extends React.Component<{ extension: Render
                 ]}
                 renderTableContents={(report: CISKubeBenchReport) => [
                     report.getName(),
-                    report.report.summary.failCount,
-                    report.report.summary.warnCount,
-                    report.report.summary.infoCount,
-                    report.report.summary.passCount,
+                    renderResult("fail", report.report.summary.failCount),
+                    renderResult("warn", report.report.summary.warnCount),
+                    renderResult("info", report.report.summary.infoCount),
+                    renderResult("pass", report.report.summary.passCount),
                     report.report.scanner.name + " " + report.report.scanner.version,
                 ]}
             />
         )
     }
+}
+
+function renderResult(result: string, count: number) {
+  if (count > 0) {
+    return (
+        <Badge className={"Badge theme-" + result} small key="result" label={count}/>
+    )
+  } else {
+    return (
+        <Badge flat small key="result" label={count}/>
+    )
+  } 
 }

--- a/src/configauditreports/page.scss
+++ b/src/configauditreports/page.scss
@@ -1,0 +1,34 @@
+.ConfigAuditReports {
+
+  .Badge {
+    &.severity-CRITICAL {
+      color: white;
+      background-color: #cc1814;
+    }
+
+    &.severity-HIGH {
+      color: white;
+      background-color: #ffa500;
+    }
+
+    &.severity-MEDIUM {
+      color: white;
+      background-color: #f0c20c;
+    }
+
+    &.severity-LOW {
+      color: white;
+      background-color: #096ab0;
+    }
+
+    &.severity-NEGLIGIBLE {
+      color: white;
+      background-color: #00b09b;
+    }
+
+    &.severity-UNKNOWN {
+      color: white;
+      background-color: #515456;
+    }
+  }
+}

--- a/src/configauditreports/page.scss
+++ b/src/configauditreports/page.scss
@@ -20,15 +20,5 @@
       color: white;
       background-color: #096ab0;
     }
-
-    &.severity-NEGLIGIBLE {
-      color: white;
-      background-color: #00b09b;
-    }
-
-    &.severity-UNKNOWN {
-      color: white;
-      background-color: #515456;
-    }
   }
 }

--- a/src/configauditreports/page.tsx
+++ b/src/configauditreports/page.tsx
@@ -1,3 +1,4 @@
+import "./page.scss"
 import {Renderer} from "@k8slens/extensions";
 import React from "react";
 import {clusterStore, store} from "./store";
@@ -95,13 +96,25 @@ export class ConfigAuditReportPage extends React.Component<{ extension: Renderer
                     <Badge flat expandable={false} key="name" label={report.getName()}
                            tooltip={report.getName()}/>,
                     report.metadata.namespace,
-                    report.report.summary.criticalCount,
-                    report.report.summary.highCount,
-                    report.report.summary.mediumCount,
-                    report.report.summary.lowCount,
+                    renderSeverity("CRITICAL", report.report.summary.criticalCount),
+                    renderSeverity("HIGH", report.report.summary.highCount),
+                    renderSeverity("MEDIUM", report.report.summary.mediumCount),
+                    renderSeverity("LOW", report.report.summary.lowCount),
                     report.report.scanner.name + " " + report.report.scanner.version,
                 ]}
             />
         )
     }
+}
+
+function renderSeverity(severity: string, count: number) {
+  if (count > 0) {
+    return (
+        <Badge className={"Badge severity-" + severity} small key="severity" label={count}/>
+    )
+  } else {
+    return (
+        <Badge flat small key="severity" label={count}/>
+    )
+  } 
 }

--- a/src/configauditreports/page.tsx
+++ b/src/configauditreports/page.tsx
@@ -114,7 +114,7 @@ function renderSeverity(severity: string, count: number) {
     )
   } else {
     return (
-        <Badge flat small key="severity" label={count}/>
+        <Badge small key="severity" label={count}/>
     )
   } 
 }

--- a/src/vulnerabilityreports/page.scss
+++ b/src/vulnerabilityreports/page.scss
@@ -21,11 +21,6 @@
       background-color: #096ab0;
     }
 
-    &.severity-NEGLIGIBLE {
-      color: white;
-      background-color: #00b09b;
-    }
-
     &.severity-UNKNOWN {
       color: white;
       background-color: #515456;

--- a/src/vulnerabilityreports/page.scss
+++ b/src/vulnerabilityreports/page.scss
@@ -1,0 +1,34 @@
+.VulnerabilityReports {
+
+  .Badge {
+    &.severity-CRITICAL {
+      color: white;
+      background-color: #cc1814;
+    }
+
+    &.severity-HIGH {
+      color: white;
+      background-color: #ffa500;
+    }
+
+    &.severity-MEDIUM {
+      color: white;
+      background-color: #f0c20c;
+    }
+
+    &.severity-LOW {
+      color: white;
+      background-color: #096ab0;
+    }
+
+    &.severity-NEGLIGIBLE {
+      color: white;
+      background-color: #00b09b;
+    }
+
+    &.severity-UNKNOWN {
+      color: white;
+      background-color: #515456;
+    }
+  }
+}

--- a/src/vulnerabilityreports/page.tsx
+++ b/src/vulnerabilityreports/page.tsx
@@ -138,7 +138,7 @@ function renderSeverity(severity: string, count: number) {
       )
     } else {
       return (
-          <Badge flat small key="severity" label={count}/>
+          <Badge small key="severity" label={count}/>
       )
     } 
 }

--- a/src/vulnerabilityreports/page.tsx
+++ b/src/vulnerabilityreports/page.tsx
@@ -1,3 +1,4 @@
+import "./page.scss"
 import {Renderer} from "@k8slens/extensions";
 import React from "react";
 import {ClusterVulnerabilityReport, VulnerabilityReport} from "./types";
@@ -101,11 +102,11 @@ export class VulnerabilityReportPage extends React.Component<{ extension: Render
                     renderName(report.getName()),
                     report.metadata.namespace,
                     renderImage(report),
-                    report.report.summary.criticalCount,
-                    report.report.summary.highCount,
-                    report.report.summary.mediumCount,
-                    report.report.summary.lowCount,
-                    report.report.summary.unknownCount,
+                    renderSeverity("CRITICAL", report.report.summary.criticalCount),
+                    renderSeverity("HIGH", report.report.summary.highCount),
+                    renderSeverity("MEDIUM", report.report.summary.mediumCount),
+                    renderSeverity("LOW", report.report.summary.lowCount),
+                    renderSeverity("UNKNOWN", report.report.summary.unknownCount),
                     renderScanner(report.report.scanner),
                 ]}
             />
@@ -128,4 +129,16 @@ function renderImage(report: VulnerabilityReport) {
     return (
         <Badge flat expandable={false} key="imageRef" label={imageRef} tooltip={imageRef}/>
     )
+}
+
+function renderSeverity(severity: string, count: number) {
+    if (count > 0) {
+      return (
+          <Badge className={"Badge severity-" + severity} small key="severity" label={count}/>
+      )
+    } else {
+      return (
+          <Badge flat small key="severity" label={count}/>
+      )
+    } 
 }


### PR DESCRIPTION
This change adds color badges to the severity counts on the report list pages, making them easier to scan visually.

This resolves issue #83.

Vulnerability Reports page:
<img width="1329" alt="Screen Shot 2022-04-21 at 1 01 58 PM" src="https://user-images.githubusercontent.com/103554953/164551405-a2cc340a-a064-4c34-8bae-aeb1ba3a1447.png">

Config Audit Reports page:
<img width="1334" alt="Screen Shot 2022-04-21 at 1 54 18 PM" src="https://user-images.githubusercontent.com/103554953/164551429-2b4b6b4f-869a-4d27-a73d-e804d34f41cc.png">

CIS Kube Bench Reports page:
<img width="1336" alt="Screen Shot 2022-04-21 at 1 54 27 PM" src="https://user-images.githubusercontent.com/103554953/164551464-5d1fcc7b-c129-4a81-b4cc-c1642977e316.png">