### PR TITLE
Improve column visibility on Report List pages

### DIFF
--- a/src/ciskubebenchreports/page.scss
+++ b/src/ciskubebenchreports/page.scss
@@ -4,15 +4,15 @@
     .TableCell {
       &.name {
         text-align: left;
-        flex-grow: 0.50;
+        flex-grow: 0.45;
       }
       &.summary {
         text-align: left;
-        flex-grow: 0.25;
+        flex-grow: 0.4;
       }
       &.scanner {
         text-align: left;
-        flex-grow: 0.25;
+        flex-grow: 0.15;
       }
     }
   }
@@ -20,6 +20,8 @@
   .Badge {
     margin-left: 4px;
     margin-right: 4px;
+    width: 3em;
+    text-align: right;
 
     &.theme-fail {
       color: white;

--- a/src/ciskubebenchreports/page.scss
+++ b/src/ciskubebenchreports/page.scss
@@ -6,7 +6,7 @@
         text-align: left;
         flex-grow: 0.50;
       }
-      &.results {
+      &.summary {
         text-align: left;
         flex-grow: 0.25;
       }

--- a/src/ciskubebenchreports/page.scss
+++ b/src/ciskubebenchreports/page.scss
@@ -1,6 +1,26 @@
 .CISKubeBenchReportsList {
 
+  .Table {
+    .TableCell {
+      &.name {
+        text-align: left;
+        flex-grow: 0.50;
+      }
+      &.results {
+        text-align: left;
+        flex-grow: 0.25;
+      }
+      &.scanner {
+        text-align: left;
+        flex-grow: 0.25;
+      }
+    }
+  }
+
   .Badge {
+    margin-left: 4px;
+    margin-right: 4px;
+
     &.theme-fail {
       color: white;
       background-color: #cc1814;

--- a/src/ciskubebenchreports/page.scss
+++ b/src/ciskubebenchreports/page.scss
@@ -2,16 +2,16 @@
 
   .Table {
     .TableCell {
+      display: flex;
+      align-items: center;
+      text-align: left;
       &.name {
-        text-align: left;
         flex-grow: 0.45;
       }
       &.summary {
-        text-align: left;
         flex-grow: 0.4;
       }
       &.scanner {
-        text-align: left;
         flex-grow: 0.15;
       }
     }

--- a/src/ciskubebenchreports/page.tsx
+++ b/src/ciskubebenchreports/page.tsx
@@ -13,10 +13,7 @@ const {
 
 enum sortBy {
     name = "name",
-    fail = "fail",
-    info = "info",
-    pass = "pass",
-    warn = "warn",
+    results = "results",
 }
 
 export class CISKubeBenchReportsPage extends React.Component<{ extension: Renderer.LensExtension }> {
@@ -28,10 +25,12 @@ export class CISKubeBenchReportsPage extends React.Component<{ extension: Render
                 className="CISKubeBenchReportsList" store={store}
                 sortingCallbacks={{
                     [sortBy.name]: (report: CISKubeBenchReport) => report.getName(),
-                    [sortBy.fail]: (report: CISKubeBenchReport) => report.report.summary.failCount,
-                    [sortBy.info]: (report: CISKubeBenchReport) => report.report.summary.infoCount,
-                    [sortBy.pass]: (report: CISKubeBenchReport) => report.report.summary.passCount,
-                    [sortBy.warn]: (report: CISKubeBenchReport) => report.report.summary.warnCount,
+                    [sortBy.results]: (report: CISKubeBenchReport) => [
+                        report.report.summary.failCount,
+                        report.report.summary.infoCount,
+                        report.report.summary.passCount,
+                        report.report.summary.warnCount,
+                    ]
                 }}
                 searchFilters={[
                     (report: CISKubeBenchReport) => report.getSearchFields()
@@ -39,18 +38,17 @@ export class CISKubeBenchReportsPage extends React.Component<{ extension: Render
                 renderHeaderTitle="CISKubeBenchReports"
                 renderTableHeader={[
                     {title: "Name", className: "name", sortBy: sortBy.name},
-                    {title: "Fail", className: "fail", sortBy: sortBy.fail},
-                    {title: "Warn", className: "pass", sortBy: sortBy.warn},
-                    {title: "Info", className: "xinfo", sortBy: sortBy.info},
-                    {title: "Pass", className: "pass", sortBy: sortBy.pass},
+                    {title: "Results", className: "results", sortBy: sortBy.results},
                     {title: "Scanner", className: "scanner"},
                 ]}
                 renderTableContents={(report: CISKubeBenchReport) => [
                     report.getName(),
-                    renderResult("fail", report.report.summary.failCount),
-                    renderResult("warn", report.report.summary.warnCount),
-                    renderResult("info", report.report.summary.infoCount),
-                    renderResult("pass", report.report.summary.passCount),
+                    [
+                        renderResult("fail", report.report.summary.failCount),
+                        renderResult("warn", report.report.summary.warnCount),
+                        renderResult("info", report.report.summary.infoCount),
+                        renderResult("pass", report.report.summary.passCount),
+                    ],
                     report.report.scanner.name + " " + report.report.scanner.version,
                 ]}
             />
@@ -59,13 +57,13 @@ export class CISKubeBenchReportsPage extends React.Component<{ extension: Render
 }
 
 function renderResult(result: string, count: number) {
-  if (count > 0) {
-    return (
-        <Badge className={"Badge theme-" + result} small key="result" label={count}/>
-    )
-  } else {
-    return (
-        <Badge small key="result" label={count}/>
-    )
-  } 
+    if (count > 0) {
+        return (
+            <Badge className={"Badge theme-" + result} key="result" label={count} tooltip={result + ": " + count}/>
+        )
+    } else {
+        return (
+            <Badge key="result" label={count}/>
+        )
+    }
 }

--- a/src/ciskubebenchreports/page.tsx
+++ b/src/ciskubebenchreports/page.tsx
@@ -63,7 +63,7 @@ function renderResult(result: string, count: number) {
         )
     } else {
         return (
-            <Badge key="result" label={count}/>
+            <Badge className="Badge" key="result" label={count}/>
         )
     }
 }

--- a/src/ciskubebenchreports/page.tsx
+++ b/src/ciskubebenchreports/page.tsx
@@ -59,11 +59,11 @@ export class CISKubeBenchReportsPage extends React.Component<{ extension: Render
 function renderResult(result: string, count: number) {
     if (count > 0) {
         return (
-            <Badge className={"Badge theme-" + result} key="result" label={count} tooltip={result + ": " + count}/>
+            <Badge className={"Badge theme-" + result} key="result" small label={count} tooltip={result + ": " + count}/>
         )
     } else {
         return (
-            <Badge className="Badge" key="result" label={count}/>
+            <Badge className="Badge" key="result" small label={count}/>
         )
     }
 }

--- a/src/ciskubebenchreports/page.tsx
+++ b/src/ciskubebenchreports/page.tsx
@@ -13,7 +13,7 @@ const {
 
 enum sortBy {
     name = "name",
-    results = "results",
+    summary = "summary",
 }
 
 export class CISKubeBenchReportsPage extends React.Component<{ extension: Renderer.LensExtension }> {
@@ -25,7 +25,7 @@ export class CISKubeBenchReportsPage extends React.Component<{ extension: Render
                 className="CISKubeBenchReportsList" store={store}
                 sortingCallbacks={{
                     [sortBy.name]: (report: CISKubeBenchReport) => report.getName(),
-                    [sortBy.results]: (report: CISKubeBenchReport) => [
+                    [sortBy.summary]: (report: CISKubeBenchReport) => [
                         report.report.summary.failCount,
                         report.report.summary.infoCount,
                         report.report.summary.passCount,
@@ -38,7 +38,7 @@ export class CISKubeBenchReportsPage extends React.Component<{ extension: Render
                 renderHeaderTitle="CISKubeBenchReports"
                 renderTableHeader={[
                     {title: "Name", className: "name", sortBy: sortBy.name},
-                    {title: "Results", className: "results", sortBy: sortBy.results},
+                    {title: "Summary", className: "summary", sortBy: sortBy.summary},
                     {title: "Scanner", className: "scanner"},
                 ]}
                 renderTableContents={(report: CISKubeBenchReport) => [

--- a/src/configauditreports/page.scss
+++ b/src/configauditreports/page.scss
@@ -10,7 +10,7 @@
         text-align: left;
         flex-grow: 0.15;
       }
-      &.results {
+      &.summary {
         text-align: left;
         flex-grow: 0.25;
       }

--- a/src/configauditreports/page.scss
+++ b/src/configauditreports/page.scss
@@ -2,20 +2,19 @@
 
   .Table {
     .TableCell {
+      display: flex;
+      align-items: center;
+      text-align: left;
       &.name {
-        text-align: left;
         flex-grow: 0.45;
       }
       &.namespace {
-        text-align: left;
         flex-grow: 0.1;
       }
       &.summary {
-        text-align: left;
         flex-grow: 0.3;
       }
       &.scanner {
-        text-align: left;
         flex-grow: 0.15;
       }
     }

--- a/src/configauditreports/page.scss
+++ b/src/configauditreports/page.scss
@@ -8,11 +8,11 @@
       }
       &.namespace {
         text-align: left;
-        flex-grow: 0.15;
+        flex-grow: 0.1;
       }
       &.summary {
         text-align: left;
-        flex-grow: 0.25;
+        flex-grow: 0.3;
       }
       &.scanner {
         text-align: left;
@@ -24,6 +24,8 @@
   .Badge {
     margin-left: 4px;
     margin-right: 4px;
+    width: 3em;
+    text-align: right;
 
     &.severity-CRITICAL {
       color: white;

--- a/src/configauditreports/page.scss
+++ b/src/configauditreports/page.scss
@@ -1,6 +1,30 @@
 .ConfigAuditReports {
 
+  .Table {
+    .TableCell {
+      &.name {
+        text-align: left;
+        flex-grow: 0.45;
+      }
+      &.namespace {
+        text-align: left;
+        flex-grow: 0.15;
+      }
+      &.results {
+        text-align: left;
+        flex-grow: 0.25;
+      }
+      &.scanner {
+        text-align: left;
+        flex-grow: 0.15;
+      }
+    }
+  }
+
   .Badge {
+    margin-left: 4px;
+    margin-right: 4px;
+
     &.severity-CRITICAL {
       color: white;
       background-color: #cc1814;

--- a/src/configauditreports/page.tsx
+++ b/src/configauditreports/page.tsx
@@ -14,7 +14,7 @@ const {
 enum sortBy {
     name = "name",
     namespace = "namespace",
-    results = "results",
+    summary = "summary",
     scanner = "scanner"
 }
 
@@ -27,7 +27,7 @@ export class ClusterConfigAuditReportPage extends React.Component<{ extension: R
                 className="ConfigAuditReports" store={clusterStore}
                 sortingCallbacks={{
                     [sortBy.name]: (report: ClusterConfigAuditReport) => report.getName(),
-                    [sortBy.results]: (report: ClusterConfigAuditReport) => [
+                    [sortBy.summary]: (report: ClusterConfigAuditReport) => [
                         report.report.summary.criticalCount,
                         report.report.summary.highCount,
                         report.report.summary.mediumCount,
@@ -41,7 +41,7 @@ export class ClusterConfigAuditReportPage extends React.Component<{ extension: R
                 renderHeaderTitle="ClusterConfigAuditReports"
                 renderTableHeader={[
                     {title: "Name", sortBy: sortBy.name},
-                    {title: "Results", className: "results", sortBy: sortBy.results},
+                    {title: "Summary", className: "summary", sortBy: sortBy.summary},
                     {title: "Scanner", sortBy: sortBy.scanner},
                 ]}
                 renderTableContents={(report: ClusterConfigAuditReport) => [
@@ -69,7 +69,7 @@ export class ConfigAuditReportPage extends React.Component<{ extension: Renderer
                 sortingCallbacks={{
                     [sortBy.name]: (report: ConfigAuditReport) => report.getName(),
                     [sortBy.namespace]: (report: ConfigAuditReport) => report.metadata.namespace,
-                    [sortBy.results]: (report: ConfigAuditReport) => [
+                    [sortBy.summary]: (report: ConfigAuditReport) => [
                         report.report.summary.criticalCount,
                         report.report.summary.highCount,
                         report.report.summary.mediumCount,
@@ -84,7 +84,7 @@ export class ConfigAuditReportPage extends React.Component<{ extension: Renderer
                 renderTableHeader={[
                     {title: "Name", className: "name", sortBy: sortBy.name},
                     {title: "Namespace", className: "namespace", sortBy: sortBy.namespace},
-                    {title: "Results", className: "results", sortBy: sortBy.results},
+                    {title: "Summary", className: "summary", sortBy: sortBy.summary},
                     {title: "Scanner", className: "scanner", sortBy: sortBy.scanner},
                 ]}
                 renderTableContents={(report: ConfigAuditReport) => [

--- a/src/configauditreports/page.tsx
+++ b/src/configauditreports/page.tsx
@@ -112,11 +112,11 @@ function renderName(name: string) {
 function renderSeverity(severity: string, count: number) {
     if (count > 0) {
         return (
-            <Badge className={"Badge severity-" + severity} key="severity" label={count} tooltip={severity + ": " + count}/>
+            <Badge className={"Badge severity-" + severity} key="severity" small label={count} tooltip={severity + ": " + count}/>
         )
     } else {
         return (
-            <Badge className="Badge" key="severity" label={count}/>
+            <Badge className="Badge" key="severity" small label={count}/>
         )
     }
 }

--- a/src/configauditreports/page.tsx
+++ b/src/configauditreports/page.tsx
@@ -14,10 +14,7 @@ const {
 enum sortBy {
     name = "name",
     namespace = "namespace",
-    critical = "critical",
-    high = "high",
-    medium = "medium",
-    low = "low",
+    results = "results",
     scanner = "scanner"
 }
 
@@ -30,10 +27,12 @@ export class ClusterConfigAuditReportPage extends React.Component<{ extension: R
                 className="ConfigAuditReports" store={clusterStore}
                 sortingCallbacks={{
                     [sortBy.name]: (report: ClusterConfigAuditReport) => report.getName(),
-                    [sortBy.critical]: (report: ClusterConfigAuditReport) => report.report.summary.criticalCount,
-                    [sortBy.high]: (report: ClusterConfigAuditReport) => report.report.summary.highCount,
-                    [sortBy.medium]: (report: ClusterConfigAuditReport) => report.report.summary.mediumCount,
-                    [sortBy.low]: (report: ClusterConfigAuditReport) => report.report.summary.lowCount,
+                    [sortBy.results]: (report: ClusterConfigAuditReport) => [
+                        report.report.summary.criticalCount,
+                        report.report.summary.highCount,
+                        report.report.summary.mediumCount,
+                        report.report.summary.lowCount
+                    ],
                     [sortBy.scanner]: (report: ClusterConfigAuditReport) => report.report.scanner.name + " " + report.report.scanner.version,
                 }}
                 searchFilters={[
@@ -42,19 +41,17 @@ export class ClusterConfigAuditReportPage extends React.Component<{ extension: R
                 renderHeaderTitle="ClusterConfigAuditReports"
                 renderTableHeader={[
                     {title: "Name", sortBy: sortBy.name},
-                    {title: "Critical", sortBy: sortBy.critical},
-                    {title: "High", sortBy: sortBy.high},
-                    {title: "Medium", sortBy: sortBy.medium},
-                    {title: "Low", sortBy: sortBy.low},
+                    {title: "Results", className: "results", sortBy: sortBy.results},
                     {title: "Scanner", sortBy: sortBy.scanner},
                 ]}
                 renderTableContents={(report: ClusterConfigAuditReport) => [
-                    <Badge flat expandable={false} key="name" label={report.getName()}
-                           tooltip={report.getName()}/>,
-                    report.report.summary.criticalCount,
-                    report.report.summary.highCount,
-                    report.report.summary.mediumCount,
-                    report.report.summary.lowCount,
+                    renderName(report.getName()),
+                    [
+                        renderSeverity("CRITICAL", report.report.summary.criticalCount),
+                        renderSeverity("HIGH", report.report.summary.highCount),
+                        renderSeverity("MEDIUM", report.report.summary.mediumCount),
+                        renderSeverity("LOW", report.report.summary.lowCount),
+                    ],
                     report.report.scanner.name + " " + report.report.scanner.version,
                 ]}
             />
@@ -72,34 +69,33 @@ export class ConfigAuditReportPage extends React.Component<{ extension: Renderer
                 sortingCallbacks={{
                     [sortBy.name]: (report: ConfigAuditReport) => report.getName(),
                     [sortBy.namespace]: (report: ConfigAuditReport) => report.metadata.namespace,
-                    [sortBy.critical]: (report: ConfigAuditReport) => report.report.summary.criticalCount,
-                    [sortBy.high]: (report: ConfigAuditReport) => report.report.summary.highCount,
-                    [sortBy.medium]: (report: ConfigAuditReport) => report.report.summary.mediumCount,
-                    [sortBy.low]: (report: ConfigAuditReport) => report.report.summary.lowCount,
-                    [sortBy.scanner]: (report: ClusterConfigAuditReport) => report.report.scanner.name + " " + report.report.scanner.version,
+                    [sortBy.results]: (report: ConfigAuditReport) => [
+                        report.report.summary.criticalCount,
+                        report.report.summary.highCount,
+                        report.report.summary.mediumCount,
+                        report.report.summary.lowCount
+                    ],
+                    [sortBy.scanner]: (report: ConfigAuditReport) => report.report.scanner.name + " " + report.report.scanner.version,
                 }}
                 searchFilters={[
                     (report: ConfigAuditReport) => report.getSearchFields()
                 ]}
                 renderHeaderTitle="ConfigAuditReports"
                 renderTableHeader={[
-                    {title: "Name", sortBy: sortBy.name},
-                    {title: "Namespace", sortBy: sortBy.namespace},
-                    {title: "Critical", sortBy: sortBy.critical},
-                    {title: "High", sortBy: sortBy.high},
-                    {title: "Medium", sortBy: sortBy.medium},
-                    {title: "Low", sortBy: sortBy.low},
-                    {title: "Scanner", sortBy: sortBy.scanner},
-
+                    {title: "Name", className: "name", sortBy: sortBy.name},
+                    {title: "Namespace", className: "namespace", sortBy: sortBy.namespace},
+                    {title: "Results", className: "results", sortBy: sortBy.results},
+                    {title: "Scanner", className: "scanner", sortBy: sortBy.scanner},
                 ]}
                 renderTableContents={(report: ConfigAuditReport) => [
-                    <Badge flat expandable={false} key="name" label={report.getName()}
-                           tooltip={report.getName()}/>,
+                    renderName(report.getName()),
                     report.metadata.namespace,
-                    renderSeverity("CRITICAL", report.report.summary.criticalCount),
-                    renderSeverity("HIGH", report.report.summary.highCount),
-                    renderSeverity("MEDIUM", report.report.summary.mediumCount),
-                    renderSeverity("LOW", report.report.summary.lowCount),
+                    [
+                        renderSeverity("CRITICAL", report.report.summary.criticalCount),
+                        renderSeverity("HIGH", report.report.summary.highCount),
+                        renderSeverity("MEDIUM", report.report.summary.mediumCount),
+                        renderSeverity("LOW", report.report.summary.lowCount),
+                    ],
                     report.report.scanner.name + " " + report.report.scanner.version,
                 ]}
             />
@@ -108,13 +104,13 @@ export class ConfigAuditReportPage extends React.Component<{ extension: Renderer
 }
 
 function renderSeverity(severity: string, count: number) {
-  if (count > 0) {
-    return (
-        <Badge className={"Badge severity-" + severity} small key="severity" label={count}/>
-    )
-  } else {
-    return (
-        <Badge small key="severity" label={count}/>
-    )
-  } 
+    if (count > 0) {
+        return (
+            <Badge className={"Badge severity-" + severity} key="severity" label={count} tooltip={severity + ": " + count}/>
+        )
+    } else {
+        return (
+            <Badge key="severity" label={count}/>
+        )
+    }
 }

--- a/src/configauditreports/page.tsx
+++ b/src/configauditreports/page.tsx
@@ -118,7 +118,7 @@ function renderSeverity(severity: string, count: number) {
         )
     } else {
         return (
-            <Badge key="severity" label={count}/>
+            <Badge className="Badge" key="severity" label={count}/>
         )
     }
 }

--- a/src/configauditreports/page.tsx
+++ b/src/configauditreports/page.tsx
@@ -104,10 +104,8 @@ export class ConfigAuditReportPage extends React.Component<{ extension: Renderer
 }
 
 function renderName(name: string) {
-  // drop replicaset/daemonset/statefulset from displayed name; keep in tooltip
-  const shortName = name.substring(name.indexOf('-')+1)
   return (
-      <Badge flat expandable={false} key="name" label={shortName} tooltip={name}/>
+      <Badge flat expandable={false} key="name" label={name} tooltip={name}/>
   )
 }
 

--- a/src/configauditreports/page.tsx
+++ b/src/configauditreports/page.tsx
@@ -103,6 +103,14 @@ export class ConfigAuditReportPage extends React.Component<{ extension: Renderer
     }
 }
 
+function renderName(name: string) {
+  // drop replicaset/daemonset/statefulset from displayed name; keep in tooltip
+  const shortName = name.substring(name.indexOf('-')+1)
+  return (
+      <Badge flat expandable={false} key="name" label={shortName} tooltip={name}/>
+  )
+}
+
 function renderSeverity(severity: string, count: number) {
     if (count > 0) {
         return (

--- a/src/vulnerabilityreports/page.scss
+++ b/src/vulnerabilityreports/page.scss
@@ -4,7 +4,7 @@
     .TableCell {
       &.name {
         text-align: left;
-        flex-grow: 0.3;
+        flex-grow: 0.25;
       }
       &.namespace {
         text-align: left;
@@ -12,11 +12,11 @@
       }
       &.repository {
         text-align: left;
-        flex-grow: 0.3;
+        flex-grow: 0.25;
       }
       &.summary {
         text-align: left;
-        flex-grow: 0.2;
+        flex-grow: 0.3;
       }
       &.scanner {
         text-align: left;
@@ -28,6 +28,8 @@
   .Badge {
     margin-left: 4px;
     margin-right: 4px;
+    width: 3em;
+    text-align: right;
 
     &.severity-CRITICAL {
       color: white;

--- a/src/vulnerabilityreports/page.scss
+++ b/src/vulnerabilityreports/page.scss
@@ -14,7 +14,7 @@
         text-align: left;
         flex-grow: 0.3;
       }
-      &.results {
+      &.summary {
         text-align: left;
         flex-grow: 0.2;
       }

--- a/src/vulnerabilityreports/page.scss
+++ b/src/vulnerabilityreports/page.scss
@@ -2,24 +2,22 @@
 
   .Table {
     .TableCell {
+      display: flex;
+      align-items: center;
+      text-align: left;
       &.name {
-        text-align: left;
         flex-grow: 0.25;
       }
       &.namespace {
-        text-align: left;
         flex-grow: 0.1;
       }
       &.repository {
-        text-align: left;
         flex-grow: 0.25;
       }
       &.summary {
-        text-align: left;
         flex-grow: 0.3;
       }
       &.scanner {
-        text-align: left;
         flex-grow: 0.1;
       }
     }

--- a/src/vulnerabilityreports/page.scss
+++ b/src/vulnerabilityreports/page.scss
@@ -1,6 +1,34 @@
 .VulnerabilityReports {
 
+  .Table {
+    .TableCell {
+      &.name {
+        text-align: left;
+        flex-grow: 0.3;
+      }
+      &.namespace {
+        text-align: left;
+        flex-grow: 0.1;
+      }
+      &.repository {
+        text-align: left;
+        flex-grow: 0.3;
+      }
+      &.results {
+        text-align: left;
+        flex-grow: 0.2;
+      }
+      &.scanner {
+        text-align: left;
+        flex-grow: 0.1;
+      }
+    }
+  }
+
   .Badge {
+    margin-left: 4px;
+    margin-right: 4px;
+
     &.severity-CRITICAL {
       color: white;
       background-color: #cc1814;

--- a/src/vulnerabilityreports/page.tsx
+++ b/src/vulnerabilityreports/page.tsx
@@ -15,7 +15,7 @@ const {
 enum sortBy {
     name = "name",
     namespace = "namespace",
-    results = "results",
+    summary = "summary",
 }
 
 export class ClusterVulnerabilityReportPage extends React.Component<{ extension: Renderer.LensExtension }> {
@@ -27,7 +27,7 @@ export class ClusterVulnerabilityReportPage extends React.Component<{ extension:
                 className="ClusterVulnerabilityReports" store={clusterStore}
                 sortingCallbacks={{
                     [sortBy.name]: (report: ClusterVulnerabilityReport) => report.getName(),
-                    [sortBy.results]: (report: ClusterVulnerabilityReport) => [
+                    [sortBy.summary]: (report: ClusterVulnerabilityReport) => [
                         report.report.summary.criticalCount,
                         report.report.summary.highCount,
                         report.report.summary.mediumCount,
@@ -42,7 +42,7 @@ export class ClusterVulnerabilityReportPage extends React.Component<{ extension:
                 renderTableHeader={[
                     {title: "Name", className: "name", sortBy: sortBy.name},
                     {title: "Image", className: "repository"},
-                    {title: "Results", className: "results", sortBy: sortBy.results},
+                    {title: "Summary", className: "summary", sortBy: sortBy.summary},
                     {title: "Scanner", className: "scanner"},
                 ]}
                 renderTableContents={(report: ClusterVulnerabilityReport) => [
@@ -73,7 +73,7 @@ export class VulnerabilityReportPage extends React.Component<{ extension: Render
                 sortingCallbacks={{
                     [sortBy.name]: (report: VulnerabilityReport) => report.getName(),
                     [sortBy.namespace]: (report: VulnerabilityReport) => report.metadata.namespace,
-                    [sortBy.results]: (report: VulnerabilityReport) => [
+                    [sortBy.summary]: (report: VulnerabilityReport) => [
                         report.report.summary.criticalCount,
                         report.report.summary.highCount,
                         report.report.summary.mediumCount,
@@ -89,7 +89,7 @@ export class VulnerabilityReportPage extends React.Component<{ extension: Render
                     {title: "Name", className: "name", sortBy: sortBy.name},
                     {title: "Namespace", className: "namespace", sortBy: sortBy.namespace},
                     {title: "Image", className: "repository"},
-                    {title: "Results", className: "results", sortBy: sortBy.results},
+                    {title: "Summary", className: "summary", sortBy: sortBy.summary},
                     {title: "Scanner", className: "scanner"},
                 ]}
                 renderTableContents={(report: VulnerabilityReport) => [

--- a/src/vulnerabilityreports/page.tsx
+++ b/src/vulnerabilityreports/page.tsx
@@ -111,8 +111,10 @@ export class VulnerabilityReportPage extends React.Component<{ extension: Render
 }
 
 function renderName(name: string) {
+    // drop replicaset/daemonset/statefulset from displayed name; keep in tooltip
+    const shortName = name.substring(name.indexOf('-')+1)
     return (
-        <Badge flat expandable={false} key="name" label={name} tooltip={name}/>
+        <Badge flat expandable={false} key="name" label={shortName} tooltip={name}/>
     )
 }
 
@@ -122,8 +124,10 @@ function renderScanner(scanner: Scanner) {
 
 function renderImage(report: VulnerabilityReport) {
     const imageRef = report.getImageRef()
+    // drop registry from displayed image reference; keep in tooltip
+    const shortImageRef = imageRef.substring(imageRef.indexOf('/')+1)
     return (
-        <Badge flat expandable={false} key="imageRef" label={imageRef} tooltip={imageRef}/>
+        <Badge flat expandable={false} key="imageRef" label={shortImageRef} tooltip={imageRef}/>
     )
 }
 

--- a/src/vulnerabilityreports/page.tsx
+++ b/src/vulnerabilityreports/page.tsx
@@ -15,11 +15,7 @@ const {
 enum sortBy {
     name = "name",
     namespace = "namespace",
-    critical = "critical",
-    high = "high",
-    medium = "medium",
-    low = "low",
-    unknown = "unknown",
+    results = "results",
 }
 
 export class ClusterVulnerabilityReportPage extends React.Component<{ extension: Renderer.LensExtension }> {
@@ -31,11 +27,13 @@ export class ClusterVulnerabilityReportPage extends React.Component<{ extension:
                 className="ClusterVulnerabilityReports" store={clusterStore}
                 sortingCallbacks={{
                     [sortBy.name]: (report: ClusterVulnerabilityReport) => report.getName(),
-                    [sortBy.critical]: (report: ClusterVulnerabilityReport) => report.report.summary.criticalCount,
-                    [sortBy.high]: (report: ClusterVulnerabilityReport) => report.report.summary.highCount,
-                    [sortBy.medium]: (report: ClusterVulnerabilityReport) => report.report.summary.mediumCount,
-                    [sortBy.low]: (report: ClusterVulnerabilityReport) => report.report.summary.lowCount,
-                    [sortBy.unknown]: (report: ClusterVulnerabilityReport) => report.report.summary.unknownCount,
+                    [sortBy.results]: (report: ClusterVulnerabilityReport) => [
+                        report.report.summary.criticalCount,
+                        report.report.summary.highCount,
+                        report.report.summary.mediumCount,
+                        report.report.summary.lowCount,
+                        report.report.summary.unknownCount,
+                    ],
                 }}
                 searchFilters={[
                     (report: ClusterVulnerabilityReport) => report.getSearchFields()
@@ -44,21 +42,19 @@ export class ClusterVulnerabilityReportPage extends React.Component<{ extension:
                 renderTableHeader={[
                     {title: "Name", className: "name", sortBy: sortBy.name},
                     {title: "Image", className: "repository"},
-                    {title: "Critical", className: "critical", sortBy: sortBy.critical},
-                    {title: "High", className: "high", sortBy: sortBy.high},
-                    {title: "Medium", className: "medium", sortBy: sortBy.medium},
-                    {title: "Low", className: "low", sortBy: sortBy.low},
-                    {title: "Unknown", sortBy: sortBy.unknown},
+                    {title: "Results", className: "results", sortBy: sortBy.results},
                     {title: "Scanner", className: "scanner"},
                 ]}
                 renderTableContents={(report: ClusterVulnerabilityReport) => [
                     renderName(report.getName()),
                     renderImage(report),
-                    report.report.summary.criticalCount,
-                    report.report.summary.highCount,
-                    report.report.summary.mediumCount,
-                    report.report.summary.lowCount,
-                    report.report.summary.unknownCount,
+                    [
+                        renderSeverity("CRITICAL", report.report.summary.criticalCount),
+                        renderSeverity("HIGH", report.report.summary.highCount),
+                        renderSeverity("MEDIUM", report.report.summary.mediumCount),
+                        renderSeverity("LOW", report.report.summary.lowCount),
+                        renderSeverity("UNKNOWN", report.report.summary.unknownCount),
+                    ],
                     renderScanner(report.report.scanner),
                 ]}
             />
@@ -77,11 +73,13 @@ export class VulnerabilityReportPage extends React.Component<{ extension: Render
                 sortingCallbacks={{
                     [sortBy.name]: (report: VulnerabilityReport) => report.getName(),
                     [sortBy.namespace]: (report: VulnerabilityReport) => report.metadata.namespace,
-                    [sortBy.critical]: (report: VulnerabilityReport) => report.report.summary.criticalCount,
-                    [sortBy.high]: (report: VulnerabilityReport) => report.report.summary.highCount,
-                    [sortBy.medium]: (report: VulnerabilityReport) => report.report.summary.mediumCount,
-                    [sortBy.low]: (report: VulnerabilityReport) => report.report.summary.lowCount,
-                    [sortBy.unknown]: (report: VulnerabilityReport) => report.report.summary.unknownCount,
+                    [sortBy.results]: (report: VulnerabilityReport) => [
+                        report.report.summary.criticalCount,
+                        report.report.summary.highCount,
+                        report.report.summary.mediumCount,
+                        report.report.summary.lowCount,
+                        report.report.summary.unknownCount,
+                    ],
                 }}
                 searchFilters={[
                     (report: VulnerabilityReport) => report.getSearchFields()
@@ -91,22 +89,20 @@ export class VulnerabilityReportPage extends React.Component<{ extension: Render
                     {title: "Name", className: "name", sortBy: sortBy.name},
                     {title: "Namespace", className: "namespace", sortBy: sortBy.namespace},
                     {title: "Image", className: "repository"},
-                    {title: "Critical", className: "critical", sortBy: sortBy.critical},
-                    {title: "High", className: "high", sortBy: sortBy.high},
-                    {title: "Medium", className: "medium", sortBy: sortBy.medium},
-                    {title: "Low", className: "low", sortBy: sortBy.low},
-                    {title: "Unknown", sortBy: sortBy.unknown},
+                    {title: "Results", className: "results", sortBy: sortBy.results},
                     {title: "Scanner", className: "scanner"},
                 ]}
                 renderTableContents={(report: VulnerabilityReport) => [
                     renderName(report.getName()),
                     report.metadata.namespace,
                     renderImage(report),
-                    renderSeverity("CRITICAL", report.report.summary.criticalCount),
-                    renderSeverity("HIGH", report.report.summary.highCount),
-                    renderSeverity("MEDIUM", report.report.summary.mediumCount),
-                    renderSeverity("LOW", report.report.summary.lowCount),
-                    renderSeverity("UNKNOWN", report.report.summary.unknownCount),
+                    [
+                        renderSeverity("CRITICAL", report.report.summary.criticalCount),
+                        renderSeverity("HIGH", report.report.summary.highCount),
+                        renderSeverity("MEDIUM", report.report.summary.mediumCount),
+                        renderSeverity("LOW", report.report.summary.lowCount),
+                        renderSeverity("UNKNOWN", report.report.summary.unknownCount),
+                    ],
                     renderScanner(report.report.scanner),
                 ]}
             />
@@ -133,12 +129,12 @@ function renderImage(report: VulnerabilityReport) {
 
 function renderSeverity(severity: string, count: number) {
     if (count > 0) {
-      return (
-          <Badge className={"Badge severity-" + severity} small key="severity" label={count}/>
-      )
+        return (
+            <Badge className={"Badge severity-" + severity} key="severity" label={count} tooltip={severity + ": " + count}/>
+        )
     } else {
-      return (
-          <Badge small key="severity" label={count}/>
-      )
-    } 
+        return (
+            <Badge key="severity" label={count}/>
+        )
+    }
 }

--- a/src/vulnerabilityreports/page.tsx
+++ b/src/vulnerabilityreports/page.tsx
@@ -130,11 +130,11 @@ function renderImage(report: VulnerabilityReport) {
 function renderSeverity(severity: string, count: number) {
     if (count > 0) {
         return (
-            <Badge className={"Badge severity-" + severity} key="severity" label={count} tooltip={severity + ": " + count}/>
+            <Badge className={"Badge severity-" + severity} key="severity" small label={count} tooltip={severity + ": " + count}/>
         )
     } else {
         return (
-            <Badge className="Badge" key="severity" label={count}/>
+            <Badge className="Badge" key="severity" small label={count}/>
         )
     }
 }

--- a/src/vulnerabilityreports/page.tsx
+++ b/src/vulnerabilityreports/page.tsx
@@ -138,7 +138,7 @@ function renderSeverity(severity: string, count: number) {
         )
     } else {
         return (
-            <Badge key="severity" label={count}/>
+            <Badge className="Badge" key="severity" label={count}/>
         )
     }
 }

--- a/src/vulnerabilityreports/page.tsx
+++ b/src/vulnerabilityreports/page.tsx
@@ -111,10 +111,8 @@ export class VulnerabilityReportPage extends React.Component<{ extension: Render
 }
 
 function renderName(name: string) {
-    // drop replicaset/daemonset/statefulset from displayed name; keep in tooltip
-    const shortName = name.substring(name.indexOf('-')+1)
     return (
-        <Badge flat expandable={false} key="name" label={shortName} tooltip={name}/>
+        <Badge flat expandable={false} key="name" label={name} tooltip={name}/>
     )
 }
 
@@ -124,10 +122,8 @@ function renderScanner(scanner: Scanner) {
 
 function renderImage(report: VulnerabilityReport) {
     const imageRef = report.getImageRef()
-    // drop registry from displayed image reference; keep in tooltip
-    const shortImageRef = imageRef.substring(imageRef.indexOf('/')+1)
     return (
-        <Badge flat expandable={false} key="imageRef" label={shortImageRef} tooltip={imageRef}/>
+        <Badge flat expandable={false} key="imageRef" label={imageRef} tooltip={imageRef}/>
     )
 }
 


### PR DESCRIPTION
This implements several changes outlined in #86 for the following pages:

* Vulnerability Reports
* Config Audit Reports
* CIS Kube Bench Reports

### Better default column widths

Using `flex-grow` styles to make some nicer default percentages for the columns.

### ~~Show only most relevant info in columns with long values~~

* ~~For the report names, I'm removing "daemonset/replicaset/statefulset" from the beginning of the string before displaying it. Users can still see the full report name in the tooltip or details page.~~
* ~~I'm doing the same for the image references by removing the image registry URL. When reviewing these results I think it's most important for users to see `repo/image:tag`. They can still see the full registry URL in the tooltip or details page.~~

### Collapse severity counts into a single column

We can reclaim a lot of space by collapsing the 4-5 columns of individual counts into a single column. I recently added color badges in #83, and these are easy to scan and understand next to each other. The display is just like the DrawerItem on the details pages.

I've added tooltips with the severity label, so users can still hover over a count to determine if it is a `HIGH` or `MEDIUM`.

### Combine sorting for severity counts

Collapsing severity counts into one column means they can't be individually sorted. However I don't think that's a very likely use case.

Instead I think most users want to sort by "How bad are these?". If we simply do a cascading sort (Critical first, then High, then Medium, etc) I think that accomplishes it perfectly. This way sorting by the Results column shows the "worst" reports at the top.

An example of all these changes together:
<img width="1235" alt="Screen Shot 2022-04-22 at 11 11 56 AM" src="https://user-images.githubusercontent.com/103554953/164776631-aaa49115-8a97-49f1-97f5-6627f04bb5d5.png">