### PR TITLE
Add Age column to Report list pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,8 @@
         "css-loader": "^5.0.0",
         "mobx": "^6.3.0",
         "mobx-react": "^7.2.0",
+        "moment": "^2.29.3",
+        "moment-timezone": "^0.5.34",
         "sass": "^1.29.0",
         "sass-loader": "^10.0.0",
         "style-loader": "^2.0.0",
@@ -2559,6 +2561,27 @@
         "react-native": {
           "optional": true
         }
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.29.3",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.3.tgz",
+      "integrity": "sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.34",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.34.tgz",
+      "integrity": "sha512-3zAEHh2hKUs3EXLESx/wsgw6IQdusOT8Bxm3D9UrHPQR7zlMmzwybC8zHEM1tQ4LJwP7fcxrWr8tuBg05fFCbg==",
+      "dev": true,
+      "dependencies": {
+        "moment": ">= 2.9.0"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {
@@ -5806,6 +5829,21 @@
       "integrity": "sha512-q5+UHIqYCOpBoFm/PElDuOhbcatvTllgRp3M1s+Hp5j0Z6XNgDbgqxawJ0ZAUEyKM8X1zs70PCuhAIzX1f4Q/g==",
       "dev": true,
       "requires": {}
+    },
+    "moment": {
+      "version": "2.29.3",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.3.tgz",
+      "integrity": "sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw==",
+      "dev": true
+    },
+    "moment-timezone": {
+      "version": "0.5.34",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.34.tgz",
+      "integrity": "sha512-3zAEHh2hKUs3EXLESx/wsgw6IQdusOT8Bxm3D9UrHPQR7zlMmzwybC8zHEM1tQ4LJwP7fcxrWr8tuBg05fFCbg==",
+      "dev": true,
+      "requires": {
+        "moment": ">= 2.9.0"
+      }
     },
     "ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "css-loader": "^5.0.0",
     "mobx": "^6.3.0",
     "mobx-react": "^7.2.0",
+    "moment": "^2.29.3",
+    "moment-timezone": "^0.5.34",
     "sass": "^1.29.0",
     "sass-loader": "^10.0.0",
     "style-loader": "^2.0.0",

--- a/src/ciskubebenchreports/page.scss
+++ b/src/ciskubebenchreports/page.scss
@@ -9,10 +9,13 @@
         flex-grow: 0.45;
       }
       &.summary {
-        flex-grow: 0.4;
+        flex-grow: 0.35;
       }
       &.scanner {
         flex-grow: 0.15;
+      }
+      &.age {
+        flex-grow: 0.05;
       }
     }
   }

--- a/src/ciskubebenchreports/page.tsx
+++ b/src/ciskubebenchreports/page.tsx
@@ -3,6 +3,7 @@ import {Renderer} from "@k8slens/extensions";
 import React from "react";
 import {store} from "./store";
 import {CISKubeBenchReport} from "./types";
+import formatDuration from "../utils/formatDuration";
 
 const {
     Component: {
@@ -14,6 +15,7 @@ const {
 enum sortBy {
     name = "name",
     summary = "summary",
+    age = "age",
 }
 
 export class CISKubeBenchReportsPage extends React.Component<{ extension: Renderer.LensExtension }> {
@@ -30,7 +32,8 @@ export class CISKubeBenchReportsPage extends React.Component<{ extension: Render
                         report.report.summary.infoCount,
                         report.report.summary.passCount,
                         report.report.summary.warnCount,
-                    ]
+                    ],
+                    [sortBy.age]: (report: CISKubeBenchReport) => report.metadata.creationTimestamp,
                 }}
                 searchFilters={[
                     (report: CISKubeBenchReport) => report.getSearchFields()
@@ -40,6 +43,7 @@ export class CISKubeBenchReportsPage extends React.Component<{ extension: Render
                     {title: "Name", className: "name", sortBy: sortBy.name},
                     {title: "Summary", className: "summary", sortBy: sortBy.summary},
                     {title: "Scanner", className: "scanner"},
+                    {title: "Age", className: "age", sortBy: sortBy.age},
                 ]}
                 renderTableContents={(report: CISKubeBenchReport) => [
                     report.getName(),
@@ -50,6 +54,7 @@ export class CISKubeBenchReportsPage extends React.Component<{ extension: Render
                         renderResult("pass", report.report.summary.passCount),
                     ],
                     report.report.scanner.name + " " + report.report.scanner.version,
+                    renderAge(report.metadata.creationTimestamp),
                 ]}
             />
         )
@@ -66,4 +71,13 @@ function renderResult(result: string, count: number) {
             <Badge className="Badge" key="result" small label={count}/>
         )
     }
+}
+
+function renderAge(timestamp: string) {
+    const creationTimestamp = new Date(timestamp).getTime();
+    return (
+        <Badge flat expandable={false} key="age"
+            label={formatDuration(Date.now() - creationTimestamp, true)}
+            tooltip={timestamp} />
+    )
 }

--- a/src/configauditreports/page.scss
+++ b/src/configauditreports/page.scss
@@ -9,13 +9,16 @@
         flex-grow: 0.45;
       }
       &.namespace {
-        flex-grow: 0.1;
+        flex-grow: 0.075;
       }
       &.summary {
         flex-grow: 0.3;
       }
       &.scanner {
-        flex-grow: 0.15;
+        flex-grow: 0.125;
+      }
+      &.age {
+        flex-grow: 0.05;
       }
     }
   }

--- a/src/configauditreports/page.tsx
+++ b/src/configauditreports/page.tsx
@@ -36,6 +36,7 @@ export class ClusterConfigAuditReportPage extends React.Component<{ extension: R
                         report.report.summary.lowCount
                     ],
                     [sortBy.scanner]: (report: ClusterConfigAuditReport) => report.report.scanner.name + " " + report.report.scanner.version,
+                    [sortBy.age]: (report: ConfigAuditReport) => report.metadata.creationTimestamp,
                 }}
                 searchFilters={[
                     (report: ClusterConfigAuditReport) => report.getSearchFields()
@@ -45,6 +46,7 @@ export class ClusterConfigAuditReportPage extends React.Component<{ extension: R
                     {title: "Name", sortBy: sortBy.name},
                     {title: "Summary", className: "summary", sortBy: sortBy.summary},
                     {title: "Scanner", sortBy: sortBy.scanner},
+                    {title: "Age", className: "age", sortBy: sortBy.age},
                 ]}
                 renderTableContents={(report: ClusterConfigAuditReport) => [
                     renderName(report.getName()),
@@ -55,6 +57,7 @@ export class ClusterConfigAuditReportPage extends React.Component<{ extension: R
                         renderSeverity("LOW", report.report.summary.lowCount),
                     ],
                     report.report.scanner.name + " " + report.report.scanner.version,
+                    renderAge(report.metadata.creationTimestamp),
                 ]}
             />
         )

--- a/src/configauditreports/page.tsx
+++ b/src/configauditreports/page.tsx
@@ -3,6 +3,7 @@ import {Renderer} from "@k8slens/extensions";
 import React from "react";
 import {clusterStore, store} from "./store";
 import {ClusterConfigAuditReport, ConfigAuditReport} from "./types";
+import formatDuration from "../utils/formatDuration";
 
 const {
     Component: {
@@ -15,7 +16,8 @@ enum sortBy {
     name = "name",
     namespace = "namespace",
     summary = "summary",
-    scanner = "scanner"
+    scanner = "scanner",
+    age = "age",
 }
 
 export class ClusterConfigAuditReportPage extends React.Component<{ extension: Renderer.LensExtension }> {
@@ -76,6 +78,7 @@ export class ConfigAuditReportPage extends React.Component<{ extension: Renderer
                         report.report.summary.lowCount
                     ],
                     [sortBy.scanner]: (report: ConfigAuditReport) => report.report.scanner.name + " " + report.report.scanner.version,
+                    [sortBy.age]: (report: ConfigAuditReport) => report.metadata.creationTimestamp,
                 }}
                 searchFilters={[
                     (report: ConfigAuditReport) => report.getSearchFields()
@@ -86,6 +89,7 @@ export class ConfigAuditReportPage extends React.Component<{ extension: Renderer
                     {title: "Namespace", className: "namespace", sortBy: sortBy.namespace},
                     {title: "Summary", className: "summary", sortBy: sortBy.summary},
                     {title: "Scanner", className: "scanner", sortBy: sortBy.scanner},
+                    {title: "Age", className: "age", sortBy: sortBy.age},
                 ]}
                 renderTableContents={(report: ConfigAuditReport) => [
                     renderName(report.getName()),
@@ -97,6 +101,7 @@ export class ConfigAuditReportPage extends React.Component<{ extension: Renderer
                         renderSeverity("LOW", report.report.summary.lowCount),
                     ],
                     report.report.scanner.name + " " + report.report.scanner.version,
+                    renderAge(report.metadata.creationTimestamp),
                 ]}
             />
         )
@@ -119,4 +124,13 @@ function renderSeverity(severity: string, count: number) {
             <Badge className="Badge" key="severity" small label={count}/>
         )
     }
+}
+
+function renderAge(timestamp: string) {
+    const creationTimestamp = new Date(timestamp).getTime();
+    return (
+        <Badge flat expandable={false} key="age"
+            label={formatDuration(Date.now() - creationTimestamp, true)}
+            tooltip={timestamp} />
+    )
 }

--- a/src/utils/formatDuration.ts
+++ b/src/utils/formatDuration.ts
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+ import moment from "moment";
+
+ /**
+  * This function formats durations in a more human readable form.
+  * @param timeValue the duration in milliseconds to format
+  */
+ export default function formatDuration(timeValue: number, compact = true) {
+   const duration = moment.duration(timeValue, "milliseconds");
+   const seconds = Math.floor(duration.asSeconds());
+   const separator = compact ? "": " ";
+ 
+   if (seconds < 0) {
+     return "0s";
+   } else if (seconds < 60*2 ) {
+     return `${seconds}s`;
+   }
+ 
+   const minutes = Math.floor(duration.asMinutes());
+ 
+   if (minutes < 10) {
+     const seconds = duration.seconds();
+ 
+     return getMeaningfulValues([minutes, seconds], ["m", "s"], separator);
+   } else if (minutes < 60 * 3) {
+     if (!compact) {
+       return getMeaningfulValues([minutes, duration.seconds()], ["m", "s"]);
+     }
+ 
+     return `${minutes}m`;
+   }
+ 
+   const hours = Math.floor(duration.asHours());
+ 
+   if(hours < 8) {
+     const minutes = duration.minutes();
+ 
+     return getMeaningfulValues([hours, minutes], ["h", "m"], separator);
+   } else if (hours < 48) {
+     if (compact) {
+       return `${hours}h`;
+     } else {
+       return getMeaningfulValues([hours, duration.minutes()], ["h", "m"]);
+     }
+   }
+ 
+   const days = Math.floor(duration.asDays());
+ 
+   if (days < 8) {
+     const hours = duration.hours();
+ 
+     if (compact) {
+       return getMeaningfulValues([days, hours], ["d", "h"], separator);
+     } else {
+       return getMeaningfulValues([days, hours, duration.minutes()], ["d", "h", "m"]);
+     }
+   }
+   const years = Math.floor(duration.asYears());
+ 
+   if (years < 2) {
+     if (compact) {
+       return `${days}d`;
+     } else {
+       return getMeaningfulValues([days, duration.hours(), duration.minutes()], ["d", "h", "m"]);
+     }
+   } else if (years < 8) {
+     const days = duration.days();
+ 
+     if (compact) {
+       return getMeaningfulValues([years, days], ["y", "d"], separator);
+     }
+   }
+ 
+   if (compact) {
+     return `${years}y`;
+   }
+ 
+   return getMeaningfulValues([years, duration.days(), duration.hours(), duration.minutes()], ["y", "d", "h", "m"]);
+ }
+ 
+ function getMeaningfulValues(values: number[], suffixes: string[], separator = " ") {
+   return values
+     .map((a, i): [number, string] => [a, suffixes[i]])
+     .filter(([dur]) => dur > 0)
+     .map(([dur, suf]) => dur + suf)
+     .join(separator);
+ }

--- a/src/vulnerabilityreports/page.scss
+++ b/src/vulnerabilityreports/page.scss
@@ -6,13 +6,13 @@
       align-items: center;
       text-align: left;
       &.name {
-        flex-grow: 0.225;
+        flex-grow: 0.25;
       }
       &.namespace {
         flex-grow: 0.075;
       }
       &.repository {
-        flex-grow: 0.225;
+        flex-grow: 0.25;
       }
       &.summary {
         flex-grow: 0.3;
@@ -21,7 +21,7 @@
         flex-grow: 0.075;
       }
       &.age {
-        flex-grow: 0.1;
+        flex-grow: 0.05;
       }
     }
   }

--- a/src/vulnerabilityreports/page.scss
+++ b/src/vulnerabilityreports/page.scss
@@ -6,18 +6,21 @@
       align-items: center;
       text-align: left;
       &.name {
-        flex-grow: 0.25;
+        flex-grow: 0.225;
       }
       &.namespace {
-        flex-grow: 0.1;
+        flex-grow: 0.075;
       }
       &.repository {
-        flex-grow: 0.25;
+        flex-grow: 0.225;
       }
       &.summary {
         flex-grow: 0.3;
       }
       &.scanner {
+        flex-grow: 0.075;
+      }
+      &.age {
         flex-grow: 0.1;
       }
     }

--- a/src/vulnerabilityreports/page.tsx
+++ b/src/vulnerabilityreports/page.tsx
@@ -36,6 +36,7 @@ export class ClusterVulnerabilityReportPage extends React.Component<{ extension:
                         report.report.summary.lowCount,
                         report.report.summary.unknownCount,
                     ],
+                    [sortBy.age]: (report: ClusterVulnerabilityReport) => report.metadata.creationTimestamp,
                 }}
                 searchFilters={[
                     (report: ClusterVulnerabilityReport) => report.getSearchFields()
@@ -46,6 +47,7 @@ export class ClusterVulnerabilityReportPage extends React.Component<{ extension:
                     {title: "Image", className: "repository"},
                     {title: "Summary", className: "summary", sortBy: sortBy.summary},
                     {title: "Scanner", className: "scanner"},
+                    {title: "Age", className: "age", sortBy: sortBy.age},
                 ]}
                 renderTableContents={(report: ClusterVulnerabilityReport) => [
                     renderName(report.getName()),
@@ -58,6 +60,7 @@ export class ClusterVulnerabilityReportPage extends React.Component<{ extension:
                         renderSeverity("UNKNOWN", report.report.summary.unknownCount),
                     ],
                     renderScanner(report.report.scanner),
+                    renderAge(report.metadata.creationTimestamp),
                 ]}
             />
         )

--- a/src/vulnerabilityreports/page.tsx
+++ b/src/vulnerabilityreports/page.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import {ClusterVulnerabilityReport, VulnerabilityReport} from "./types";
 import {clusterStore, store} from "./store";
 import {Scanner} from "../starboard/types";
+import formatDuration from "../utils/formatDuration";
 
 const {
     Component: {
@@ -16,6 +17,7 @@ enum sortBy {
     name = "name",
     namespace = "namespace",
     summary = "summary",
+    age = "age",
 }
 
 export class ClusterVulnerabilityReportPage extends React.Component<{ extension: Renderer.LensExtension }> {
@@ -80,6 +82,7 @@ export class VulnerabilityReportPage extends React.Component<{ extension: Render
                         report.report.summary.lowCount,
                         report.report.summary.unknownCount,
                     ],
+                    [sortBy.age]: (report: VulnerabilityReport) => report.metadata.creationTimestamp,
                 }}
                 searchFilters={[
                     (report: VulnerabilityReport) => report.getSearchFields()
@@ -91,6 +94,7 @@ export class VulnerabilityReportPage extends React.Component<{ extension: Render
                     {title: "Image", className: "repository"},
                     {title: "Summary", className: "summary", sortBy: sortBy.summary},
                     {title: "Scanner", className: "scanner"},
+                    {title: "Age", className: "age", sortBy: sortBy.age},
                 ]}
                 renderTableContents={(report: VulnerabilityReport) => [
                     renderName(report.getName()),
@@ -104,6 +108,7 @@ export class VulnerabilityReportPage extends React.Component<{ extension: Render
                         renderSeverity("UNKNOWN", report.report.summary.unknownCount),
                     ],
                     renderScanner(report.report.scanner),
+                    renderAge(report.metadata.creationTimestamp),
                 ]}
             />
         )
@@ -137,4 +142,14 @@ function renderSeverity(severity: string, count: number) {
             <Badge className="Badge" key="severity" small label={count}/>
         )
     }
+}
+
+function renderAge(timestamp: string) {
+    const creationTimestamp = new Date(timestamp).getTime();
+    return (
+        <Badge flat expandable={false} key="age"
+            label={formatDuration(Date.now() - creationTimestamp, true)}
+            // tooltip={<LocaleDate date={timestamp} />} />
+            tooltip={timestamp} />
+    )
 }

--- a/src/vulnerabilityreports/page.tsx
+++ b/src/vulnerabilityreports/page.tsx
@@ -149,7 +149,6 @@ function renderAge(timestamp: string) {
     return (
         <Badge flat expandable={false} key="age"
             label={formatDuration(Date.now() - creationTimestamp, true)}
-            // tooltip={<LocaleDate date={timestamp} />} />
             tooltip={timestamp} />
     )
 }


### PR DESCRIPTION
Closes #89.

This adds an Age column to the 3 current Report list pages, just like `kubectl get vulnerabilityreport` shows:

* Vulnerability Reports
* Config Audit Reports
* CIS Kube Bench Reports

<img width="1137" alt="Screen Shot 2022-05-19 at 9 31 17 PM" src="https://user-images.githubusercontent.com/103554953/169450952-d0fcab15-b770-4036-af38-6469059bf039.png">

It also has the absolute date as a tooltip on each Age value:
<img width="531" alt="Screen Shot 2022-05-19 at 9 32 04 PM" src="https://user-images.githubusercontent.com/103554953/169451049-94626cee-0f35-450f-a110-3a1aa18c66ad.png">

A couple of side notes, @danielpacak perhaps you can weigh in:

1. I wanted to use `formatDuration()` and `LocaleDate` from the Lens codebase to format datetimes. However they are not exported in the extension-specific NPM module, `@k8slens/extensions`, so I can't access them in the Starboard extension (as far as I can tell).
2. Instead of using those, I brought over `formatDuration()` in a new folder called `utils/`.
3. I _also_ don't have access to `UserStore` from the Lens codebase, which means I can't see what the user's local timezone is for converting the absolute date. Instead I've just left it as UTC.

I'm somewhat new to Node/React/Electron—is there some other trick to being able to use these? Or are they not exported for a reason?